### PR TITLE
Fix "ZoneId" bug, add MQTT autoreconnect feature

### DIFF
--- a/evogateway.py
+++ b/evogateway.py
@@ -547,7 +547,7 @@ def mqtt_publish(device, command, msg, topic=None, auto_ts=True):
   try:
       if not topic:
         topic = "{}/{}/{}".format(MQTT_PUB_TOPIC, to_snake(device), command.strip())
-      timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%XZ")
+      timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%XZ")
       mqtt_client.publish(topic, msg, 0, True)
       if auto_ts:
         mqtt_client.publish("{}{}".format(topic,"_ts"), timestamp, 0, True)
@@ -1558,7 +1558,7 @@ def send_command_to_evohome(command):
     command.arg_desc if command.arg_desc !="[]" else ":"), command.serial_port.tag)
 
   if mqtt_client and mqtt_client.is_connected:
-    timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%XZ")
+    timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%XZ")
     mqtt_client.publish("{}/failed".format(SENT_COMMAND_TOPIC), False, 0, True) # Reset this before the others, to avoid incorrect interpretation of status by 3rd party apps 
     # mqtt_client.publish("{}/failed_ts".format(SENT_COMMAND_TOPIC), "", 0, True)
     mqtt_client.publish("{}/retries".format(SENT_COMMAND_TOPIC), command.retries, 0, True)

--- a/evogateway.py
+++ b/evogateway.py
@@ -446,9 +446,6 @@ def initialise_mqtt_client(mqtt_client):
 
     display_and_log (SYSTEM_MSG_TAG,"Connecting to mqtt broker '%s'" % MQTT_SERVER)
     mqtt_client.connect(MQTT_SERVER, port=1883, keepalive=60, bind_address="")
-
-    display_and_log (SYSTEM_MSG_TAG,"Subscribing to mqtt topic '%s'" % MQTT_SUB_TOPIC)
-    mqtt_client.subscribe(MQTT_SUB_TOPIC)
     mqtt_client.loop_start()
   except Exception as e:
     display_and_log ("ERROR", "'{}' on line {} [Command {}, data: '{}', port: {}]".format(str(e), sys.exc_info()[-1].tb_lineno, msg.command_name, data, port_tag))
@@ -461,6 +458,13 @@ def mqtt_on_connect(client, userdata, flags, rc):
   if rc == 0:
       client.is_connected = True #set flag
       display_and_log (SYSTEM_MSG_TAG,"MQTT connection established with broker")
+      try:
+        display_and_log (SYSTEM_MSG_TAG,"Subscribing to mqtt topic '%s'" % MQTT_SUB_TOPIC)
+        mqtt_client.subscribe(MQTT_SUB_TOPIC)
+      except Exception as e:
+        display_and_log ("ERROR", "'{}' on line {} [Command {}, data: '{}', port: {}]".format(str(e), sys.exc_info()[-1].tb_lineno, msg.command_name, data, port_tag))
+        print(traceback.format_exc())
+        return None
   else:
       client.is_connected = False
       display_and_log (SYSTEM_MSG_TAG,"MQTT connection failed (code {})".format(rc))

--- a/evogateway.py
+++ b/evogateway.py
@@ -441,7 +441,6 @@ def initialise_mqtt_client(mqtt_client):
     mqtt_client.on_connect = mqtt_on_connect
     mqtt_client.on_message = mqtt_on_message
     mqtt_client.on_log = mqtt_on_log
-    mqtt_client.on_disconnect = mqtt_on_disconnect
     mqtt_client.is_connected = False # Custom attribute so that we can track connection status
 
     display_and_log (SYSTEM_MSG_TAG,"Connecting to mqtt broker '%s'" % MQTT_SERVER)
@@ -470,16 +469,6 @@ def mqtt_on_connect(client, userdata, flags, rc):
       display_and_log (SYSTEM_MSG_TAG,"MQTT connection failed (code {})".format(rc))
       if DEBUG:
           display_and_log(SYSTEM_MSG_TAG, "[DEBUG] mqtt userdata: {}, flags: {}, client: {}".format(userdata, flags, client))
-
-
-def mqtt_on_disconnect(client, userdata, rc):
-    ''' mqtt disconnection event processing '''
-    client.loop_stop()
-    client.is_connected = False
-    if rc != 0:
-        display_and_log(SYSTEM_MSG_TAG, "[WARN] Unexpected disconnection.")
-        if DEBUG:
-            display_and_log(SYSTEM_MSG_TAG, "[DEBUG] mqtt rc: {}, userdata: {}, client: {}".format(rc, userdata, client))
 
 
 def mqtt_on_log(client, obj, level, string):


### PR DESCRIPTION
I ran into some issues running both the 2.0.0 and master branches, mainly caused by part of the code expecting the devices dict to contain zoneId and other parts expecting zone_id. Initially I started fixing these by using the dict.get() method, but that was causing the zones to just turn to 0.

This was causing errors like these:

```
2020-10-15 14:13:13 |     | ERROR               | ''zoneId'' on line 725 [Command ZONE_TEMPERATURE, data: '---  I --- 01:180412 --:------ 01:180412 30C9 021 0007C901085402078A030BF804073D05073E0608BB', port: 1]
Traceback (most recent call last):
  File "evogateway.py", line 725, in process_received_message
    COMMANDS[msg.command_code](msg)
  File "evogateway.py", line 875, in zone_temperature
    zone_id = devices[msg.source_id]["zoneId"]
KeyError: 'zoneId'
```

I just noticed that these were also reported in issue #18 

Second minor issue is that the BDR91 is being recognized as a controller instead of a relay, presumably because it's often used as a on/off boiler controller. 

