### PR TITLE
Add CONTROLLER_ID to config sample file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,17 @@ Configuration parameters are defined in a separate file, `evogateway.cfg`, with 
     MQTT_SUB_TOPIC   = evohome/gateway/command
 
     [SENDER]
-    THIS_GATEWAY_ID     = 30:071715
+    THIS_GATEWAY_ID     = 18:056026
     THIS_GATEWAY_NAME   = EvoGateway
+    CONTROLLER_ID       = 01:139901
+
     COMMAND_RESEND_TIMEOUT_SECS = 30
     COMMAND_RESEND_ATTEMPTS = 5
 
     [MISC]
     LOG_DROPPED_PACKETS = False
 
+The value for the CONTROLLER_ID can be found in the 'DEVICES_FILE' or 'NEW_DEVICES_FILE'. Use the device ID that starts with 01:. 
 
 #### Device Definitions
 The `DEVICES_FILE` is a *json* file containing a list of the devices on the evohome network, based on their internal device IDs, e.g:

--- a/evogateway.cfg.sample
+++ b/evogateway.cfg.sample
@@ -11,8 +11,8 @@ DEVICES_FILE     = devices.json
 NEW_DEVICES_FILE = devices_new.json   
 
 [MQTT]
-MQTT_PUB_TOPIC      = evohome/gateway
-MQTT_SUB_TOPIC      = evohome/gateway/command
+MQTT_PUB_TOPIC   = evohome/gateway
+MQTT_SUB_TOPIC   = evohome/gateway/command
 MQTT_SERVER      = 172.16.2.8
 MQTT_USER        = openhab
 MQTT_PW          = xxxx
@@ -22,10 +22,11 @@ MQTT_CLIENTID    = evoGateway
 # Apparently the ID 18:056026 is hardcoded into the evofw3. Previous evofw2 fifo branch had 19:056026 ???
 THIS_GATEWAY_ID             = 18:056026
 THIS_GATEWAY_NAME           = EvoGateway
+CONTROLLER_ID               = 01:xxxxxx
 
 # Try to match an acknowledgement from Controller for outbound commands (unless overridden via individual command json with 'wait_for_ack') 
 COMMAND_RESEND_TIMEOUT_SECS = 10
-COMMAND_RESEND_ATTEMPTS= 3
+COMMAND_RESEND_ATTEMPTS     = 3
 AUTO_RESET_PORTS_ON_FAILURE = True
 
 [MISC]


### PR DESCRIPTION
The CONTROLLER_ID is missing from the sample config file.
Because of that the default CONTROLLER_ID is always used which is hard coded.